### PR TITLE
feat: add select category

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.11.0",
         "recoil": "^0.7.7",
         "styled-components": "^5.3.10"
       },
@@ -1073,6 +1074,14 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.0.tgz",
+      "integrity": "sha512-N13NRw3T2+6Xi9J//3CGLsK2OqC8NMme3d/YX+nh05K9YHWGcv8DycHJrqGScSP4T75o8IN6nqIMhVFU8ohg8w==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -1718,6 +1727,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.0.tgz",
+      "integrity": "sha512-hTm6KKNpj9SDG4syIWRjCU219O0RZY8RUPobCFt9p+PlF7nnkRgMoh2DieTKvw3F3Mw6zg565HGnSv8BuoY5oQ==",
+      "dependencies": {
+        "@remix-run/router": "1.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.0.tgz",
+      "integrity": "sha512-Q3mK1c/CYoF++J6ZINz7EZzwlgSOZK/kc7lxIA7PhtWhKju4KfF1WHqlx0kVCIFJAWztuYVpXZeljEbds8z4Og==",
+      "dependencies": {
+        "@remix-run/router": "1.6.0",
+        "react-router": "6.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,10 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@emotion/react": "^11.10.8",
+        "@emotion/styled": "^11.10.8",
         "@mui/material": "^5.12.2",
+        "@mui/styled-engine": "^5.12.0",
         "@mui/styled-engine-sc": "^5.12.0",
         "axios": "^1.4.0",
         "react": "^18.2.0",
@@ -374,17 +377,51 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.8.tgz",
+      "integrity": "sha512-gxNky50AJL3AlkbjvTARiwAqei6/tNUxDZPSKd+3jqWVM3AmdVTTdpjHorR/an/M0VJqdsuq5oGcFH+rjtyujQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.1",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.1.4"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@emotion/cache": {
-      "version": "11.10.7",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
-      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.8.tgz",
+      "integrity": "sha512-5fyqGHi51LU95o7qQ/vD1jyvC4uCY5GcBT+UgP4LHdpO9jPDlXqhrRr9/wCKmfoAvh5G/F7aOh4MwQa+8uEqhA==",
       "dependencies": {
         "@emotion/memoize": "^0.8.0",
         "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.1.3"
+        "stylis": "4.1.4"
       }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.0",
@@ -399,10 +436,72 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
+    "node_modules/@emotion/react": {
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.8.tgz",
+      "integrity": "sha512-ZfGfiABtJ1P1OXqOBsW08EgCDp5fK6C5I8hUJauc/VcJBGSzqAirMnFslhFWnZJ/w5HxPI36XbvMV0l4KZHl+w==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.8",
+        "@emotion/cache": "^11.10.8",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+    },
     "node_modules/@emotion/sheet": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
       "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.8.tgz",
+      "integrity": "sha512-gow0lF4Uw/QEdX2REMhI8v6wLOabPKJ+4HKNF0xdJ2DJdznN6fxaXpQOx6sNkyBhSUL558Rmcu1Lq/MYlVo4vw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.8",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
@@ -413,6 +512,14 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emotion/utils": {
       "version": "1.2.0",
@@ -1082,6 +1189,11 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -1181,6 +1293,20 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/babel-plugin-styled-components": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.1.tgz",
@@ -1227,6 +1353,14 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelize": {
@@ -1305,8 +1439,22 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
@@ -1370,6 +1518,14 @@
       "integrity": "sha512-TFeOKd98TpJzRHkr4Aorn16QkMnuCQuGAE6IZ0wYF+qkbSfMPqjplvRppR02tMUpVxZz8nyBNvVm9lIZsqrbPQ==",
       "dev": true
     },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.17.18",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
@@ -1424,6 +1580,11 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -1470,6 +1631,11 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1492,6 +1658,17 @@
       "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
       "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1513,6 +1690,37 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1529,6 +1737,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1540,6 +1753,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -1620,6 +1838,47 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/picocolors": {
@@ -1798,6 +2057,30 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dependencies": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
@@ -1835,6 +2118,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
@@ -1875,9 +2166,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
-      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.4.tgz",
+      "integrity": "sha512-USf5pszRYwuE6hg9by0OkKChkQYEXfkeTtm0xKw+jqQhwyjCVLdYyMBK7R+n7dhzsblAWJnGxju4vxq5eH20GQ=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -1888,6 +2179,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/to-fast-properties": {
@@ -1981,6 +2283,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.11.0",
     "recoil": "^0.7.7",
     "styled-components": "^5.3.10"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emotion/react": "^11.10.8",
+    "@emotion/styled": "^11.10.8",
     "@mui/material": "^5.12.2",
+    "@mui/styled-engine": "^5.12.0",
     "@mui/styled-engine-sc": "^5.12.0",
     "axios": "^1.4.0",
     "react": "^18.2.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,8 +1,14 @@
-function App() {
+import { Routes, Route } from "react-router-dom"
+import GlobalStyle from "./components/GlobalStyle/GlobalStyle"
+import SearchPage from "./pages/SearchPage"
 
+function App() {
   return (
-    <div>
-      Hello world
+    <div className="App">
+      <GlobalStyle />
+      <Routes>
+        <Route path="/search" element={<SearchPage />}></Route>
+      </Routes>
     </div>
   )
 }

--- a/client/src/components/CategoryBox/CategoryBox.jsx
+++ b/client/src/components/CategoryBox/CategoryBox.jsx
@@ -5,8 +5,22 @@ import {
   CategoryBtn
 } from "./CategoryBox.styled";
 import { StyledEngineProvider } from '@mui/styled-engine'
+import { useState } from "react";
 
 function CategoryBox(props) {
+  function btnClick(e) {
+    if((e.target.classList).contains('active')){
+      (e.target.classList).remove('active');
+      const tempList = props.state.filter(el => el !== (e.target.innerText));
+      props.handler(tempList);
+      return;
+    }
+
+    e.target.classList.add('active');
+    props.handler([e.target.innerText, ...props.state]);
+    return;
+  }
+
   return(
     <StyledEngineProvider injectFirst>
       <CategoryBoxContainer>
@@ -16,8 +30,11 @@ function CategoryBox(props) {
         <CategoryContent>
           {
             props.buttons &&
-            (props.buttons).map(btn => (
-              <CategoryBtn key={btn.id} >{btn}</CategoryBtn>
+            (props.buttons).map((btn, idx) => (
+              <CategoryBtn 
+                key={idx} 
+                onClick={btnClick}
+                className="category-btn">{btn}</CategoryBtn>
             ))
           }
         </CategoryContent>

--- a/client/src/components/CategoryBox/CategoryBox.jsx
+++ b/client/src/components/CategoryBox/CategoryBox.jsx
@@ -5,7 +5,6 @@ import {
   CategoryBtn
 } from "./CategoryBox.styled";
 import { StyledEngineProvider } from '@mui/styled-engine'
-import { useState } from "react";
 
 function CategoryBox(props) {
   function btnClick(e) {

--- a/client/src/components/CategoryBox/CategoryBox.jsx
+++ b/client/src/components/CategoryBox/CategoryBox.jsx
@@ -1,0 +1,9 @@
+import { CategoryBoxContainer } from "./CategoryBox.styled";
+
+function CategoryBox() {
+  return(
+    <CategoryBoxContainer></CategoryBoxContainer>
+  )
+}
+
+export default CategoryBox;

--- a/client/src/components/CategoryBox/CategoryBox.jsx
+++ b/client/src/components/CategoryBox/CategoryBox.jsx
@@ -1,8 +1,28 @@
-import { CategoryBoxContainer } from "./CategoryBox.styled";
+import { 
+  CategoryBoxContainer,
+  CategoryTitle,
+  CategoryContent,
+  CategoryBtn
+} from "./CategoryBox.styled";
+import { StyledEngineProvider } from '@mui/styled-engine'
 
-function CategoryBox() {
+function CategoryBox(props) {
   return(
-    <CategoryBoxContainer></CategoryBoxContainer>
+    <StyledEngineProvider injectFirst>
+      <CategoryBoxContainer>
+        <CategoryTitle>
+          <div id="category-box__title">{props.title}</div>
+        </CategoryTitle>
+        <CategoryContent>
+          {
+            props.buttons &&
+            (props.buttons).map(btn => (
+              <CategoryBtn key={btn.id} >{btn}</CategoryBtn>
+            ))
+          }
+        </CategoryContent>
+      </CategoryBoxContainer>
+    </StyledEngineProvider>
   )
 }
 

--- a/client/src/components/CategoryBox/CategoryBox.styled.js
+++ b/client/src/components/CategoryBox/CategoryBox.styled.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const CategoryBoxContainer = styled.div`
+  font-size: 22px;
+  width: 42.8636em;
+  height: 7.36363em;
+  background-color: black;
+`;

--- a/client/src/components/CategoryBox/CategoryBox.styled.js
+++ b/client/src/components/CategoryBox/CategoryBox.styled.js
@@ -1,8 +1,38 @@
 import styled from 'styled-components';
+import Button from '@mui/material/Button';
 
 export const CategoryBoxContainer = styled.div`
-  font-size: 22px;
-  width: 42.8636em;
-  height: 7.36363em;
-  background-color: black;
+  font-size: 18px;
+  width: 38rem;
+  height: 7.5em;
+  border: 1px solid #bdbdbd;
+`;
+
+export const CategoryTitle = styled.div`
+  width: inherit;
+  height: 2.4em;
+  background-color: rgba(5, 117, 152, 0.25);
+  position: relative;
+
+  #category-box__title {
+    font-size: 16px;
+    font-weight: 600;
+    position: absolute;
+    top: 50%;
+    left: 1em;
+    transform: translateY(-50%);
+  }
+`;
+
+export const CategoryContent = styled.div`
+  width: inherit;
+`
+
+export const CategoryBtn = styled(Button)`
+  background-color: #ececec;
+  border-radius: 15px;
+  font-weight: 600;
+  color: #7d7d7d;
+  padding: 4px 10px;
+  margin: 10px 4px;
 `;

--- a/client/src/components/CategoryBox/CategoryBox.styled.js
+++ b/client/src/components/CategoryBox/CategoryBox.styled.js
@@ -4,13 +4,13 @@ import Button from '@mui/material/Button';
 export const CategoryBoxContainer = styled.div`
   font-size: 18px;
   width: 38rem;
-  height: 7.5em;
+  height: 8.1rem;
   border: 1px solid #bdbdbd;
 `;
 
 export const CategoryTitle = styled.div`
   width: inherit;
-  height: 2.4em;
+  height: 2.5rem;
   background-color: rgba(5, 117, 152, 0.25);
   position: relative;
 
@@ -26,13 +26,18 @@ export const CategoryTitle = styled.div`
 
 export const CategoryContent = styled.div`
   width: inherit;
+
+  .active {
+    background-color: #0057ff;
+    color: #fff;
+  }
 `
 
 export const CategoryBtn = styled(Button)`
   background-color: #ececec;
-  border-radius: 15px;
+  border-radius: 0.8rem;
   font-weight: 600;
   color: #7d7d7d;
-  padding: 4px 10px;
-  margin: 10px 4px;
+  padding: 0.2222rem 0.6rem;
+  margin: 0.5556rem 0.2222rem 0 0.3333rem;
 `;

--- a/client/src/components/EtcBox/EtcBox.jsx
+++ b/client/src/components/EtcBox/EtcBox.jsx
@@ -5,13 +5,15 @@ import {
   RegionSelect,
   AgeBox,
   RegionBox,
-  KeywordBox
+  KeywordBox,
+  ButtonBox
 } from "./EtcBox.styled";
 import { StyledEngineProvider } from '@mui/styled-engine'
 import { 
   FormControl,
   InputLabel,
-  MenuItem
+  MenuItem,
+  Button
 } from '@mui/material';
 
 function EtcBox(props) {
@@ -24,6 +26,9 @@ function EtcBox(props) {
                   '서대문구', '마포구', '양천구', '강서구', '구로구', '금천구',
                   '영등포구', '동작구', '관악구', '서초구', '강남구', '송파구', '강동구'];
   
+  function resetHandler() {
+    window.location.reload();
+  }
 
   return(
     <StyledEngineProvider injectFirst>
@@ -100,6 +105,14 @@ function EtcBox(props) {
                 placeholder="검색어를 입력해주세요"
                 onChange={e => props.keywordHandler(e.target.value)}></input>
           </KeywordBox>
+          <ButtonBox>
+            <Button className="etc-footer__btn" 
+                    id="etc-footer__btn-reset"
+                    onClick={resetHandler}>초기화</Button>
+            <Button className="etc-footer__btn" 
+                    id="etc-footer__btn-search"
+                    onClick={props.submitHandler}>검색</Button>
+          </ButtonBox>
         </EtcContent>
       </EtcBoxContainer>
     </StyledEngineProvider>

--- a/client/src/components/EtcBox/EtcBox.jsx
+++ b/client/src/components/EtcBox/EtcBox.jsx
@@ -1,0 +1,84 @@
+import { 
+  EtcBoxContainer, 
+  EtcTitle,
+  EtcContent,
+  RegionSelect,
+  AgeBox,
+  RegionBox,
+  KeywordBox
+} from "./EtcBox.styled";
+import { StyledEngineProvider } from '@mui/styled-engine'
+import { 
+  FormControl,
+  InputLabel,
+  MenuItem
+} from '@mui/material';
+
+function EtcBox() {
+  const sido = ['서울특별시', '부산광역시', '대구광역시', '인천광역시',
+                '광주광역시', '대전광역시', '울산광역시', '세종특별자치시',
+                '경기도', '강원도', '충청북도', '충청남도', '전라북도',
+                '전라남도', '경상북도', '경상남도', '제주특별자치도'];
+  const seoulGu = ['종로구', '중구', '용산구', '성동구', '광진구', '동대문구',
+                  '중랑구', '성북구', '강북구', '도봉구', '노원구', '은평구',
+                  '서대문구', '마포구', '양천구', '강서구', '구로구', '금천구',
+                  '영등포구', '동작구', '관악구', '서초구', '강남구', '송파구', '강동구'];
+  
+
+  return(
+    <StyledEngineProvider injectFirst>
+      <EtcBoxContainer>
+        <EtcTitle>
+          <div id="category-box__title">기타 선택</div>
+        </EtcTitle>
+        <EtcContent>
+          <AgeBox>
+            <div className="etc-label">나이</div>
+            <div id="etc-age__box">
+              <div className="etc-age__text" >만</div>
+              <input type="text" id="etc-age__input" placeholder="0"></input>
+              <div className="etc-age__text">세</div>
+            </div>
+          </AgeBox>
+          <RegionBox>
+            <div className="etc-label">지역</div>
+            <FormControl size="small" className="etc-region__form">
+              <InputLabel className="etc-region__input-label">시/도</InputLabel>
+              <RegionSelect
+                label="시/도"
+              >
+                {
+                  sido &&
+                  sido.map((el, idx) => (
+                    <MenuItem value={idx} key={idx}>{el}</MenuItem>
+                  ))
+                }
+              </RegionSelect>
+            </FormControl>
+            <FormControl size="small" className="etc-region__form">
+              <InputLabel className="etc-region__input-label">시/군/구</InputLabel>
+              <RegionSelect
+                label="시/군/구"
+              >
+                {
+                  seoulGu &&
+                  seoulGu.map((el, idx) => (
+                    <MenuItem value={idx} key={idx}>{el}</MenuItem>
+                  ))
+                }
+              </RegionSelect>
+            </FormControl>
+          </RegionBox>
+          <KeywordBox>
+            <div className="etc-label">키워드</div>
+            <input type="text" 
+                id="etc-keyword__input"
+                placeholder="검색어를 입력해주세요"></input>
+          </KeywordBox>
+        </EtcContent>
+      </EtcBoxContainer>
+    </StyledEngineProvider>
+  )
+}
+
+export default EtcBox;

--- a/client/src/components/EtcBox/EtcBox.jsx
+++ b/client/src/components/EtcBox/EtcBox.jsx
@@ -14,7 +14,7 @@ import {
   MenuItem
 } from '@mui/material';
 
-function EtcBox() {
+function EtcBox(props) {
   const sido = ['서울특별시', '부산광역시', '대구광역시', '인천광역시',
                 '광주광역시', '대전광역시', '울산광역시', '세종특별자치시',
                 '경기도', '강원도', '충청북도', '충청남도', '전라북도',
@@ -36,7 +36,11 @@ function EtcBox() {
             <div className="etc-label">나이</div>
             <div id="etc-age__box">
               <div className="etc-age__text" >만</div>
-              <input type="text" id="etc-age__input" placeholder="0"></input>
+              <input 
+                type="text" 
+                id="etc-age__input" 
+                placeholder="0"
+                onChange={e => props.ageHandler(Number(e.target.value))}></input>
               <div className="etc-age__text">세</div>
             </div>
           </AgeBox>
@@ -46,6 +50,7 @@ function EtcBox() {
               <InputLabel className="etc-region__input-label">시/도</InputLabel>
               <RegionSelect
                 label="시/도"
+                onChange={e => props.sidoHandler(sido[Number(e.target.value)])}
               >
                 {
                   sido &&
@@ -59,6 +64,7 @@ function EtcBox() {
               <InputLabel className="etc-region__input-label">시/군/구</InputLabel>
               <RegionSelect
                 label="시/군/구"
+                onChange={e => props.sidoHandler(seoulGu[Number(e.target.value)])}
               >
                 {
                   seoulGu &&
@@ -73,7 +79,8 @@ function EtcBox() {
             <div className="etc-label">키워드</div>
             <input type="text" 
                 id="etc-keyword__input"
-                placeholder="검색어를 입력해주세요"></input>
+                placeholder="검색어를 입력해주세요"
+                onChange={e => props.keywordHandler(e.target.value)}></input>
           </KeywordBox>
         </EtcContent>
       </EtcBoxContainer>

--- a/client/src/components/EtcBox/EtcBox.jsx
+++ b/client/src/components/EtcBox/EtcBox.jsx
@@ -50,12 +50,21 @@ function EtcBox(props) {
               <InputLabel className="etc-region__input-label">시/도</InputLabel>
               <RegionSelect
                 label="시/도"
-                onChange={e => props.sidoHandler(sido[Number(e.target.value)])}
+                onChange={e => props.sidoHandler(e.target.value)}
+                defaultValue="서울특별시"
               >
+                <MenuItem
+                  disabled
+                  value=''
+                  sx={{
+                    display: "none",
+                  }}>
+                  <em>-</em>
+                </MenuItem>
                 {
                   sido &&
                   sido.map((el, idx) => (
-                    <MenuItem value={idx} key={idx}>{el}</MenuItem>
+                    <MenuItem value={el} key={idx}>{el}</MenuItem>
                   ))
                 }
               </RegionSelect>
@@ -64,12 +73,21 @@ function EtcBox(props) {
               <InputLabel className="etc-region__input-label">시/군/구</InputLabel>
               <RegionSelect
                 label="시/군/구"
-                onChange={e => props.sidoHandler(seoulGu[Number(e.target.value)])}
+                onChange={e => props.sigunguHandler(e.target.value)}
+                defaultValue="동작구"
               >
+                <MenuItem
+                  disabled
+                  value=''
+                  sx={{
+                    display: "none",
+                  }}>
+                  <em>-</em>
+                </MenuItem>
                 {
                   seoulGu &&
                   seoulGu.map((el, idx) => (
-                    <MenuItem value={idx} key={idx}>{el}</MenuItem>
+                    <MenuItem value={el} key={idx}>{el}</MenuItem>
                   ))
                 }
               </RegionSelect>

--- a/client/src/components/EtcBox/EtcBox.styled.js
+++ b/client/src/components/EtcBox/EtcBox.styled.js
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+import { 
+  CategoryBoxContainer,
+  CategoryTitle,
+  CategoryContent
+} from '../CategoryBox/CategoryBox.styled';
+import Select from '@mui/material/Select';
+
+export const EtcBoxContainer = styled(CategoryBoxContainer)`
+  height: 12rem;
+`;
+
+export const EtcTitle = styled(CategoryTitle)``;
+
+export const EtcContent = styled(CategoryContent)`
+  display: flex;
+  flex-wrap: wrap;
+  position: relative;
+
+  .etc-label {
+    width: 4rem;
+    height: 2rem;
+    font-weight: 700;
+    font-size: 16px;
+  }
+
+`;
+
+export const RegionSelect = styled(Select)`
+  width: 8.5rem;
+  height: 2.2rem;
+`;
+
+export const AgeBox = styled.div`
+  width: 9rem;
+  height: 1.625rem;
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+
+  #etc-age__box {
+    width: 6rem;
+    height: 1.4rem;
+    display: flex;
+    font-size: 15px;
+    border: 1px solid #7D7D7D;
+    border-radius: 0.625rem;
+    padding: 5px;
+  }
+
+  .etc-age__text {
+    width: 0.9375rem;
+    height: 1.5625rem;
+  }
+
+  #etc-age__input {
+    width: 3rem;
+    height: 1.5625rem;
+    border: none;
+    text-align: right;
+    outline: none;
+  }
+`;
+
+export const RegionBox = styled.div`
+  width: 22rem;
+  height: 2.6rem;
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  top: 1rem;
+  left: 14rem;
+`;
+
+export const KeywordBox = styled.div`
+  width: 35rem;
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  top: 4rem;
+  left: 1rem;
+
+  #etc-keyword__input {
+    width: 30rem;
+    outline: none;
+    border: 1px solid #7D7D7D;
+    border-radius: 0.625rem;
+    padding-left: 10px;
+  }
+`;

--- a/client/src/components/EtcBox/EtcBox.styled.js
+++ b/client/src/components/EtcBox/EtcBox.styled.js
@@ -61,6 +61,7 @@ export const AgeBox = styled.div`
     border: none;
     text-align: right;
     outline: none;
+    color: #057598;
   }
 `;
 

--- a/client/src/components/EtcBox/EtcBox.styled.js
+++ b/client/src/components/EtcBox/EtcBox.styled.js
@@ -7,7 +7,7 @@ import {
 import Select from '@mui/material/Select';
 
 export const EtcBoxContainer = styled(CategoryBoxContainer)`
-  height: 12rem;
+  height: 13rem;
 `;
 
 export const EtcTitle = styled(CategoryTitle)``;
@@ -38,7 +38,7 @@ export const AgeBox = styled.div`
   justify-content: space-between;
   position: absolute;
   top: 1rem;
-  left: 1rem;
+  left: 1.5rem;
 
   #etc-age__box {
     width: 6rem;
@@ -72,7 +72,7 @@ export const RegionBox = styled.div`
   justify-content: space-between;
   position: absolute;
   top: 1rem;
-  left: 14rem;
+  left: 14.5rem;
 `;
 
 export const KeywordBox = styled.div`
@@ -81,7 +81,8 @@ export const KeywordBox = styled.div`
   justify-content: space-between;
   position: absolute;
   top: 4rem;
-  left: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
 
   #etc-keyword__input {
     width: 30rem;
@@ -91,3 +92,31 @@ export const KeywordBox = styled.div`
     padding-left: 10px;
   }
 `;
+
+export const ButtonBox = styled.div`
+  width: 23rem;
+  height: 2.6rem;
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  top: 7rem;
+  left: 50%;
+  transform: translateX(-50%);
+
+  .etc-footer__btn {
+    width: 11rem;
+    height: 2.6rem;
+    font-weight: 600;
+    border-radius: 0.5rem;
+  }
+
+  #etc-footer__btn-reset {
+    background-color: #d9d9d9;
+    color: #fff;
+  }
+
+  #etc-footer__btn-search {
+    background-color: rgba(5, 117, 152, 0.25);;
+    color: #000;
+  }
+`

--- a/client/src/components/GlobalStyle/GlobalStyle.jsx
+++ b/client/src/components/GlobalStyle/GlobalStyle.jsx
@@ -1,0 +1,10 @@
+import { createGlobalStyle } from "styled-components";
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    width: 100%;
+    margin: 0;
+  }
+`;
+
+export default GlobalStyle;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import { BrowserRouter } from 'react-router-dom'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+  <BrowserRouter>
     <App />
-  </React.StrictMode>,
+  </BrowserRouter>
 )

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -1,4 +1,5 @@
 import CategoryBox from "../components/CategoryBox/CategoryBox";
+import EtcBox from "../components/EtcBox/EtcBox";
 import { useState } from "react";
 
 function SearchPage() {
@@ -22,6 +23,7 @@ function SearchPage() {
           buttons={interestList}
           state={interest}
           handler={setInterest}></CategoryBox>
+      <EtcBox></EtcBox>
     </div>
   )
 }

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -1,15 +1,28 @@
 import CategoryBox from "../components/CategoryBox/CategoryBox";
+import { useState } from "react";
 
 function SearchPage() {
-  const household = ['저소득', '장애인', '한부모·조손', '다자녀', '다문화·탈북민', '보훈대상자'];
-  const interest = ['신체건강', '정신건강', '생활지원', '주거', 
+  const [household, setHousehold] = useState([]);
+  const [interest, setInterest] = useState([]);
+
+  const householdList = ['저소득', '장애인', '한부모·조손', '다자녀', '다문화·탈북민', '보훈대상자'];
+  const interestList = ['신체건강', '정신건강', '생활지원', '주거', 
                     '일자리', '문화·여가', '안전·위기', '보육', 
-                    '교육', '입양·위탁', '보호·돌봄', '서민금융', '법률']
+                    '교육', '입양·위탁', '보호·돌봄', '서민금융', '법률'];
 
   return(
-    <CategoryBox 
-        title="가구상황"
-        buttons={household}></CategoryBox>
+    <div id="search-page">
+      <CategoryBox 
+          title="가구상황"
+          buttons={householdList}
+          state={household}
+          handler={setHousehold}></CategoryBox>
+      <CategoryBox 
+          title="관심분야"
+          buttons={interestList}
+          state={interest}
+          handler={setInterest}></CategoryBox>
+    </div>
   )
 }
 

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -6,14 +6,24 @@ function SearchPage() {
   const [household, setHousehold] = useState([]);
   const [interest, setInterest] = useState([]);
   const [age, setAge] = useState(0);
-  const [sido, setSido] = useState('');
-  const [sigungu, setSigungu] = useState('');
+  // '시/도', '시/군/구' -> defaultValue
+  const [sido, setSido] = useState('서울특별시');
+  const [sigungu, setSigungu] = useState('동작구');
   const [keyword, setKeyword] = useState('');
 
   const householdList = ['저소득', '장애인', '한부모·조손', '다자녀', '다문화·탈북민', '보훈대상자'];
   const interestList = ['신체건강', '정신건강', '생활지원', '주거', 
                     '일자리', '문화·여가', '안전·위기', '보육', 
                     '교육', '입양·위탁', '보호·돌봄', '서민금융', '법률'];
+
+  function submitHandler() {
+    console.log(household);
+    console.log(interest);
+    console.log(age);
+    console.log(sido);
+    console.log(sigungu);
+    console.log(keyword);
+  }
 
   return(
     <div id="search-page">
@@ -31,7 +41,8 @@ function SearchPage() {
           ageHandler={setAge}
           sidoHandler={setSido}
           sigunguHandler={setSigungu}
-          keywordHandler={setKeyword} ></EtcBox>
+          keywordHandler={setKeyword}
+          submitHandler={submitHandler} ></EtcBox>
     </div>
   )
 }

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -1,8 +1,15 @@
 import CategoryBox from "../components/CategoryBox/CategoryBox";
 
 function SearchPage() {
+  const household = ['저소득', '장애인', '한부모·조손', '다자녀', '다문화·탈북민', '보훈대상자'];
+  const interest = ['신체건강', '정신건강', '생활지원', '주거', 
+                    '일자리', '문화·여가', '안전·위기', '보육', 
+                    '교육', '입양·위탁', '보호·돌봄', '서민금융', '법률']
+
   return(
-    <CategoryBox></CategoryBox>
+    <CategoryBox 
+        title="가구상황"
+        buttons={household}></CategoryBox>
   )
 }
 

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -5,6 +5,10 @@ import { useState } from "react";
 function SearchPage() {
   const [household, setHousehold] = useState([]);
   const [interest, setInterest] = useState([]);
+  const [age, setAge] = useState(0);
+  const [sido, setSido] = useState('');
+  const [sigungu, setSigungu] = useState('');
+  const [keyword, setKeyword] = useState('');
 
   const householdList = ['저소득', '장애인', '한부모·조손', '다자녀', '다문화·탈북민', '보훈대상자'];
   const interestList = ['신체건강', '정신건강', '생활지원', '주거', 
@@ -23,7 +27,11 @@ function SearchPage() {
           buttons={interestList}
           state={interest}
           handler={setInterest}></CategoryBox>
-      <EtcBox></EtcBox>
+      <EtcBox
+          ageHandler={setAge}
+          sidoHandler={setSido}
+          sigunguHandler={setSigungu}
+          keywordHandler={setKeyword} ></EtcBox>
     </div>
   )
 }

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -1,0 +1,9 @@
+import CategoryBox from "../components/CategoryBox/CategoryBox";
+
+function SearchPage() {
+  return(
+    <CategoryBox></CategoryBox>
+  )
+}
+
+export default SearchPage;


### PR DESCRIPTION
## 추가 기능
- '복지검색' 카테고리 선택 컴포넌트 구현
- '가구상황', '관심분야'는 UI가 똑같아서 `CategoryBox` 컴포넌트로 묶었고,
'기타 선택'은 `CategoryBox` 스타일 상속 받아서 따로 `EtcBox` 라는 컴포넌트로 만들었습니다.
- 각 필드 선택시 모든 값은 `SearchPage`의 각 state에 반영됨 -> api 나오면 바로 요청 보낼 수 있도록!
- 초기화 버튼 : 일단 그냥 화면 리렌더링 하는 함수로 임시 구현 ㅎㅎ
- 검색 버튼 : api가 아직 안 나와서 일단 전체 입력값 콘솔에 출력해주는 함수로 간단하게 구현함!
- 그리고 지역 부분의 '시/군/구'는 일단 서울특별시의 자치구로만 하드코딩 했습니다 ㅇ.ㅇ

## 추후 개선
- UI 디테일 수정
- 필드 선택시 `SearchPage`의 state에 반영되는 부분 recoil 로 개선할 수 있을 듯?
- 검색 버튼 : api 나오면 요청 전송하는 로직으로 변경

## 화면 캡쳐
`/search` 경로에 라우팅 해놓았어요!

![image](https://user-images.githubusercontent.com/50830078/236158261-818eb178-b070-4215-9dc4-2445b50aca4e.png)

↑ 기본 화면

![image](https://user-images.githubusercontent.com/50830078/236158530-f03ea43b-8bb1-49e3-bc2d-6ebc7cdd2cd1.png)

↑ 각 필드 선택시 이런 화면