### PR TITLE
feat: 복지 검색 api 연결

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "@mui/styled-engine-sc": "^5.12.0",
         "@mui/styles": "^5.12.3",
         "axios": "^1.4.0",
+        "dotenv": "^16.0.3",
         "kakao-sdk": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -44,6 +45,22 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@angular/core": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.0.2.tgz",
+      "integrity": "sha512-uPa2A+nVqwljDepahMn2ndgWg/a14VnTqgunXJP9q/Us98I/YGdryake4aTfXHUAdLON/R9IzomiXeFDYp5cJQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.10.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.5.3 || ^7.4.0",
+        "zone.js": "~0.13.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -894,6 +911,15 @@
       "resolved": "https://registry.npmjs.org/@fontsource/public-sans/-/public-sans-4.5.12.tgz",
       "integrity": "sha512-sa6lr+lQQB1Iif2xyWZmcCbReV3dj6m0CNXw5xbDwKO4BPeZxz+G+Vy9zWdzhaKpjmK6Ap2wIn1x79XVcvMRtQ=="
     },
+    "node_modules/@ionic-native/core": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-4.20.0.tgz",
+      "integrity": "sha512-8ppRT4zXKwtalv9HJomLQjDnMfPAiKdNUQSSKpwZePmI+8TpYRL7UNr0o0hmjiTXx1oGcKQFzHpDc1M2yeR3BA==",
+      "peer": true,
+      "peerDependencies": {
+        "rxjs": "^5.5.11"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -1639,6 +1665,14 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.376",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.376.tgz",
@@ -2344,6 +2378,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "peer": true,
+      "dependencies": {
+        "symbol-observable": "1.0.1"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -2439,6 +2485,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -2451,6 +2506,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
@@ -2542,6 +2603,15 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/zone.js": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.0.tgz",
+      "integrity": "sha512-7m3hNNyswsdoDobCkYNAy5WiUulkMd3+fWaGT9ij6iq3Zr/IwJo4RMCYPSDjT+r7tnPErmY9sZpKhWQ8S5k6XQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@mui/styles": "^5.12.3",
     "axios": "^1.4.0",
+    "dotenv": "^16.0.3",
     "kakao-sdk": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/components/CategoryBox/CategoryBox.styled.js
+++ b/client/src/components/CategoryBox/CategoryBox.styled.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const CategoryBoxContainer = styled.div`
   font-size: 18px;
-  width: 38rem;
+  width: 46rem;
   height: 8.1rem;
   border: 1px solid #bdbdbd;
 `;
@@ -10,7 +10,7 @@ export const CategoryBoxContainer = styled.div`
 export const CategoryTitle = styled.div`
   width: inherit;
   height: 2.5rem;
-  background-color: rgba(5, 117, 152, 0.25);
+  background-color: #CEE5D0;
   position: relative;
 
   #category-box__title {
@@ -27,7 +27,7 @@ export const CategoryContent = styled.div`
   width: inherit;
 
   .active {
-    background-color: #0057ff;
+    background-color: #61A167;
     color: #fff;
   }
 `
@@ -41,4 +41,6 @@ export const CategoryBtn = styled.button`
   padding: 0 0.6rem;
   margin: 0.5556rem 0.2222rem 0 0.3333rem;
   border: 0;
+  transition: all ease-in-out 0.3s;
+  cursor: pointer;
 `;

--- a/client/src/components/CategoryContainer/CategoryContainer.jsx
+++ b/client/src/components/CategoryContainer/CategoryContainer.jsx
@@ -2,60 +2,74 @@ import { CategoryWrapper } from "./CategoryContainer.styled";
 import CategoryBox from "../CategoryBox/CategoryBox";
 import EtcBox from "../EtcBox/EtcBox";
 import { useState } from "react";
+import TitleBox from "../TitleBox/TitleBox";
+import axios from "axios";
 
 export default function CategoryContainer() {
   const [household, setHousehold] = useState([]);
   const [interest, setInterest] = useState([]);
-  const [age, setAge] = useState(0);
+  const [age, setAge] = useState(50);
   // '시/도', '시/군/구' -> defaultValue
   const [sido, setSido] = useState("서울특별시");
   const [sigungu, setSigungu] = useState("동작구");
   const [keyword, setKeyword] = useState("");
+  const [page, setPage] = useState(1);
 
-  const householdList = [
-    "저소득",
-    "장애인",
-    "한부모·조손",
-    "다자녀",
-    "다문화·탈북민",
-    "보훈대상자",
-  ];
-  const interestList = [
-    "신체건강",
-    "정신건강",
-    "생활지원",
-    "주거",
-    "일자리",
-    "문화·여가",
-    "안전·위기",
-    "보육",
-    "교육",
-    "입양·위탁",
-    "보호·돌봄",
-    "서민금융",
-    "법률",
-  ];
+  const householdCode = {
+    "다문화·탈북민": "010",
+    "다자녀": "020",
+    "보훈대상자": "030",
+    "장애인": "040",
+    "저소득": "050",
+    "한부모·조손": "060"
+  };
+  
+  const interestCode = {
+    "신체건강": "010",
+    "정신건강": "020",
+    "생활지원": "030",
+    "주거": "040",
+    "일자리": "050",
+    "문화·여가": "060",
+    "안전·위기": "070",
+    "임신·출산": "080",
+    "보육": "090",
+    "교육": "100",
+    "입양·위탁": "110",
+    "보호·돌봄": "120",
+    "서민금융": "130",
+    "법률": "140"
+  }
 
   function submitHandler() {
-    console.log(household);
-    console.log(interest);
-    console.log(age);
-    console.log(sido);
-    console.log(sigungu);
-    console.log(keyword);
+    axios.get(`${import.meta.env.VITE_APP_HOST}/api/programs/list`, {
+      params: {
+        serviceKey: `${import.meta.env.VITE_SERVICE_KEY}`,
+        pageNo: page,
+        numOfRows: 9,
+        lifeArray: '005,006',
+        trgterIndvdlArray: household.join(','),
+        intrsThemaArray: interest.join(','),
+        age: (age == 0) ? '' : age,
+        ctpvNm: sido,
+        searchWrd: keyword
+      }
+    }).then((res) => console.log(res))
+    .catch((err) => console.log(err));
   }
 
   return (
     <CategoryWrapper>
+      <TitleBox title="복지 검색" desc="적절한 옵션을 선택하여 검색해 보세요!" />
       <CategoryBox
         title="가구상황"
-        buttons={householdList}
+        buttons={Object.keys(householdCode)}
         state={household}
         handler={setHousehold}
       ></CategoryBox>
       <CategoryBox
         title="관심분야"
-        buttons={interestList}
+        buttons={Object.keys(interestCode)}
         state={interest}
         handler={setInterest}
       ></CategoryBox>

--- a/client/src/components/CategoryContainer/CategoryContainer.jsx
+++ b/client/src/components/CategoryContainer/CategoryContainer.jsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import TitleBox from "../TitleBox/TitleBox";
 import axios from "axios";
 
-export default function CategoryContainer() {
+export default function CategoryContainer(props) {
   const [household, setHousehold] = useState([]);
   const [interest, setInterest] = useState([]);
   const [age, setAge] = useState(50);
@@ -54,7 +54,9 @@ export default function CategoryContainer() {
         ctpvNm: sido,
         searchWrd: keyword
       }
-    }).then((res) => console.log(res))
+    }).then((res) => {
+      props.handler(res.data.data.servList);
+    })
     .catch((err) => console.log(err));
   }
 

--- a/client/src/components/CategoryContainer/CategoryContainer.styled.js
+++ b/client/src/components/CategoryContainer/CategoryContainer.styled.js
@@ -4,6 +4,7 @@ export const CategoryWrapper = styled.div`
   width: 49rem;
   height: 37rem;
   position: absolute;
-  top: 120px;
-  left: 430px;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
 `;

--- a/client/src/components/CategoryContainer/CategoryContainer.styled.js
+++ b/client/src/components/CategoryContainer/CategoryContainer.styled.js
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 
 export const CategoryWrapper = styled.div`
-  width: 58.9375rem;
-  height: 37.4375rem;
+  width: 49rem;
+  height: 37rem;
   position: absolute;
-  top: 233px;
-  left: 432px;
+  top: 120px;
+  left: 430px;
 `;

--- a/client/src/components/EtcBox/EtcBox.styled.js
+++ b/client/src/components/EtcBox/EtcBox.styled.js
@@ -32,7 +32,7 @@ export const RegionSelect = styled(Select)`
 `;
 
 export const AgeBox = styled.div`
-  width: 9rem;
+  width: 10.3rem;
   height: 1.625rem;
   display: flex;
   justify-content: space-between;
@@ -76,7 +76,7 @@ export const RegionBox = styled.div`
 `;
 
 export const KeywordBox = styled.div`
-  width: 35rem;
+  width: 43rem;
   display: flex;
   justify-content: space-between;
   position: absolute;
@@ -85,7 +85,7 @@ export const KeywordBox = styled.div`
   transform: translateX(-50%);
 
   #etc-keyword__input {
-    width: 30rem;
+    width: 40rem;
     outline: none;
     border: 1px solid #7D7D7D;
     border-radius: 0.625rem;
@@ -113,10 +113,12 @@ export const ButtonBox = styled.div`
   #etc-footer__btn-reset {
     background-color: #d9d9d9;
     color: #fff;
+    cursor: pointer;
   }
 
   #etc-footer__btn-search {
-    background-color: rgba(5, 117, 152, 0.25);;
+    background-color: #CEE5D0;
     color: #000;
+    cursor: pointer;
   }
 `

--- a/client/src/components/ProgramCard/ProgramCard.jsx
+++ b/client/src/components/ProgramCard/ProgramCard.jsx
@@ -7,47 +7,45 @@ import {
 import empty_star from "../../assets/empty_star.png";
 import { useNavigate } from "react-router-dom";
 
-function ProgramCard() {
+function ProgramCard(prop) {
   const navigate = useNavigate();
 
-  // api 나왔을 때 변경이 쉽도록 데이터 동적 반영
-  const props = {
-    title: '복지 제도 제목',
-    detail: '복지 제도에 대한 간략한 정보가 출력됩니다!',
-    inquiries: '1577-6635',
-    department: '보건복지부',
-    household: '저소득',
-    interest: '신체건강',
-    programIdx: 1
-  };
-
   function goDetail() {
-    navigate(`/search/${props.programIdx}`);
+    navigate(`/search/${prop.program.servId}`);
+  }
+
+  function reduceLen(len, str) {
+    if(str.length >= len) {
+      str = str.slice(0, len);
+      str += '...';
+      return str;
+    }
+    return str;
   }
 
   return(
     <CardContainer>
       <CardHeader>
-        <div id="program-title">{props.title}</div>
+        <div id="program-title">{prop.program.servNm ? reduceLen(6, prop.program.servNm) : '복지 제도 제목'}</div>
         <img id="program-star" src={empty_star} alt="star" />
       </CardHeader>
-      <div id="program-detail-short">{props.detail}</div>
+      <div id="program-detail-short">{prop.program.servDgst ? reduceLen(30, prop.program.servDgst) : '복지 제도에 대한 간략한 정보가 출력됩니다.'}</div>
       <CardInfoList>
         <CardInfo>
-          <div className="program-info-entry">문의처</div>
-          <div className="program-info-content">{props.inquiries}</div>          
+          <div className="program-info-entry">지급방법</div>
+          <div className="program-info-content">{prop.program.srvPvsnNm ? reduceLen(7, prop.program.srvPvsnNm) : '현금지급'}</div>          
         </CardInfo>
         <CardInfo>
           <div className="program-info-entry">담당부처</div>
-          <div className="program-info-content">{props.department}</div>          
+          <div className="program-info-content">{prop.program.bizChrDeptNm ? reduceLen(7, prop.program.bizChrDeptNm) : '보건복지부'}</div>          
         </CardInfo>
         <CardInfo>
           <div className="program-info-entry">가구상황</div>
-          <div className="program-info-content">{props.household}</div>          
+          <div className="program-info-content">{prop.program.lifeNmArray ? reduceLen(7, prop.program.lifeNmArray) : '저소득'}</div>          
         </CardInfo>
         <CardInfo>
           <div className="program-info-entry">관심분야</div>
-          <div className="program-info-content">{props.interest}</div>          
+          <div className="program-info-content">{prop.program.intrsThemaNmArray ? reduceLen(7, prop.program.intrsThemaNmArray) : '신체건강'}</div>          
         </CardInfo>
       </CardInfoList>
       <button id="program-detail-btn" onClick={goDetail}>상세정보</button>

--- a/client/src/components/ProgramCard/ProgramCard.styled.js
+++ b/client/src/components/ProgramCard/ProgramCard.styled.js
@@ -5,10 +5,8 @@ export const CardContainer = styled.div`
   height: 22.8125rem;
   border: 1px solid #7d7d7d;
   border-radius: 10px;
-  position: absolute;
-  // 추후 수정
-  top: 50rem;
-  left: 25rem;
+  position: relative;
+  margin: 1rem 1rem 0 0 ;
 
   #program-detail-short {
     width: 13.75rem;
@@ -25,8 +23,8 @@ export const CardContainer = styled.div`
   #program-detail-btn {
     width: 13.75rem;
     height: 2.5625rem;
-    background-color: #057598;
-    color: #fff;
+    background-color: #CEE5D0;
+    color: #000;
     border: 0;
     border-radius: 0.625rem;
     position: absolute;
@@ -60,6 +58,7 @@ export const CardHeader = styled.div`
     position: absolute;
     bottom: 0;
     right: 0;
+    cursor: pointer;
   }
   
 `;

--- a/client/src/components/ProgramContainer/ProgramContainer.jsx
+++ b/client/src/components/ProgramContainer/ProgramContainer.jsx
@@ -1,0 +1,27 @@
+import { 
+  ProgramWrapper,
+  EmptyProgram
+} from "./ProgramContainer.styled";
+import ProgramCard from "../ProgramCard/ProgramCard";
+
+function ProgramContainer(props) {
+
+  return(
+    <ProgramWrapper>
+      {
+        props.programs &&
+        props.programs.map((el, idx) => (
+          <ProgramCard program={el} key={idx} />
+        ))
+      }
+      {
+        !props.programs &&
+        (
+          <EmptyProgram>해당 옵션에 해당하는 복지 정보가 없습니다!</EmptyProgram>
+        )
+      }
+    </ProgramWrapper>
+  )
+}
+
+export default ProgramContainer;

--- a/client/src/components/ProgramContainer/ProgramContainer.styled.js
+++ b/client/src/components/ProgramContainer/ProgramContainer.styled.js
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const ProgramWrapper = styled.div`
+  width: 55rem;
+  height: 70rem;
+  display: flex;
+  flex-wrap: wrap;
+  position: absolute;
+  top: 38rem;
+`;
+
+export const EmptyProgram = styled.div`
+  width: 46rem;
+  height: 5rem;
+  background-color: #ececec;
+  border-radius: 1rem;
+  border: 0;
+  text-align: center;
+  line-height: 5rem;
+  color: #7d7d7d;
+  font-size: 17px;
+  font-weight: 600;
+  margin-top: 1rem;
+  position: absolute;
+  top: 0;
+  left: 3rem;
+`

--- a/client/src/components/SearchContent/SearchContent.jsx
+++ b/client/src/components/SearchContent/SearchContent.jsx
@@ -1,0 +1,28 @@
+import { SearchContentContainer } from "./SearchContent.styled";
+import CategoryContainer from "../CategoryContainer/CategoryContainer";
+import ProgramContainer from "../ProgramContainer/ProgramContainer";
+import { useState } from "react";
+
+function SearchContent() {
+  // const [programs, setPrograms] = useState([{
+  //   program: {
+  //     servNm: '복지제도 제목',
+  //     servDgst: '복지제도에 대한 간략한 정보가 들어갑니다.',
+  //     srvPvsnNm: '현금지급',
+  //     bizChrDeptNm: '보건복지부',
+  //     intrsThemaNmArray: '신체건강',
+  //     lifeNmArray: '저소득',
+  //     servId: 'WLF00002235'
+  //   }
+  // }]);
+  const [programs, setPrograms] = useState();
+
+  return(
+    <SearchContentContainer>
+      <CategoryContainer handler={setPrograms} />
+      <ProgramContainer programs={programs} />
+    </SearchContentContainer>
+  )
+}
+
+export default SearchContent;

--- a/client/src/components/SearchContent/SearchContent.styled.js
+++ b/client/src/components/SearchContent/SearchContent.styled.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const SearchContentContainer = styled.div`
+  width: 55rem;
+  height: max-content;
+  position: absolute;
+  top: 120px;
+  left: 430px;
+`;

--- a/client/src/components/TitleBox/TitleBox.jsx
+++ b/client/src/components/TitleBox/TitleBox.jsx
@@ -1,0 +1,14 @@
+import { TitleBoxContainer } from "./TitleBox.styled";
+
+function TitleBox(props) {
+  const { title, desc } = props;
+
+  return(
+    <TitleBoxContainer>
+      <div id="title-box__title">{title}</div>
+      <div id="title-box__desc">{desc}</div>
+    </TitleBoxContainer>
+  )
+}
+
+export default TitleBox;

--- a/client/src/components/TitleBox/TitleBox.styled.js
+++ b/client/src/components/TitleBox/TitleBox.styled.js
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+export const TitleBoxContainer = styled.div`
+  width: max-content;
+  height: 6rem;
+
+  #title-box__title {
+    width: max-content;
+    height: 2rem;
+    font-size: 25px;
+    font-weight: 600;
+    margin-bottom: 5px;
+  }
+
+  #title-box__desc {
+    width: max-content;
+    height: 1rem;
+    color: #7d7d7d;
+  }
+`;

--- a/client/src/pages/Search.jsx
+++ b/client/src/pages/Search.jsx
@@ -1,12 +1,6 @@
 import React from "react";
-// import Container from "@mui/material/Container";
-// import Box from "@mui/material/Box";
 import Sidebar from "../components/Sidebar";
-// import CategoryBox from "../components/CategoryBox/CategoryBox";
-// import EtcBox from "../components/EtcBox/EtcBox";
-// import Paper from "../components/Paper";
-import ProgramCard from "../components/ProgramCard/ProgramCard";
-import CategoryContainer from "../components/CategoryContainer/CategoryContainer";
+import SearchContent from "../components/SearchContent/SearchContent";
 
 export default function Search() {
   return (
@@ -18,8 +12,7 @@ export default function Search() {
           { title: "음성 검색" },
         ]}
       />
-      <CategoryContainer />
-      <ProgramCard />
+      <SearchContent />
     </>
   );
 }


### PR DESCRIPTION
### 추가 기능
- 복지 검색 부분 api 연결
- 복지 검색 이전이거나 선택한 옵션에 해당하는 복지 프로그램 목록 없는 경우 메시지 출력
- 검색 결과에 따른 ProgramCard 노출
- 일정 글자수 넘어가는 문자열들은 거기까지 자르고, "..." 추가되게 구현함
- 서버 주소 및 복지 정보 api 서비스 키 환경변수에 추가(카톡으로 공유하겠습니다)

### 추후 개선
- 페이지네이션 추가(지금은 그냥 9개씩만 출력되게 했습니다.)
- 검색 결과 개수 출력(ex. 총 25건이 조회되었습니다.)

### 주의할 점
- 몇몇 카테고리를 선택해서 검색하면 데이터가 많이 없어서, 혹시 테스트 해보고 싶으시면, 아무런 키워드나 카테고리를 선택하지 않고 그냥 "검색" 버튼 한 번만 눌러주심 되겠습니당

### 화면 캡쳐
![image](https://github.com/googoo9918/software-project-bokha/assets/50830078/1f1b0d47-5667-43d3-9cb8-a281f053a011)
↑ 검색 X

![image](https://github.com/googoo9918/software-project-bokha/assets/50830078/27cda902-e36e-469f-9ff5-065e2667c042)
↑ 검색 O

✔️ 그리고 위에 헤더바 지금은 아래로 내리면 background-color 없어지게 구현하신 거 같은데 안 없어지게 변경해주시면 감사하겠습니다!!