### PR TITLE
feat: 복지 검색 상세페이지 api 연결

### DIFF
--- a/client/src/components/ProgramDetail/ProgramDetail.jsx
+++ b/client/src/components/ProgramDetail/ProgramDetail.jsx
@@ -3,50 +3,134 @@ import {
   DetailHeader,
   DetailInfoBox,
   DetailInfoLine,
-  DetailContent
+  DetailContent,
+  DetailContentBlock
 } from "./ProgramDetail.styled";
+import { useParams } from 'react-router-dom';
+import axios from "axios";
+import { useState, useEffect } from "react";
 
 function ProgramDetail () {
-  // 나중에 programIdx 로 데이터 받아올듯
-  // const { programIdx } = useParams();
+  const { programIdx } = useParams();
+  const [detailInfo, setDetailInfo] = useState({
+    servNm: '복지 제도 제목',
+    servDgst: '복지 제도에 대한 세부 내용이 들어갑니다.',
+    inqplCtadrList: [
+      {
+        wlfareInfoReldCn: '전화번호'
+      }
+    ],
+    lifeNmArray: '가구상황',
+    intrsThemaNmArray: '관심분야',
+    bizChrDeptNm: '담당부처',
+    alwServCn: '급여 정보',
+    aplyMtdCn: '신청 방법',
+    sprtTrgtCn: '지원 대상',
+    slctCritCn: '선정 기준',
+    basfrmList: [
+      {
+        wlfareInfoReldCn: 'https://www.naver.com/'
+      }
+    ]
+  });
   
-  const data = {
-    title: '복지 제도 제목',
-    inquiries: '1577-6635',
-    department: '보건복지부',
-    organization: '노인정책과',
-    household: '저소득',
-    interest: '신체건강',
-    detail: '복지 제도에 대한 세부 내용이 들어간다.'
+  function getDetail() {
+    axios.get(`${import.meta.env.VITE_APP_HOST}/api/programs/detail`,{
+      params: {
+        serviceKey: `${import.meta.env.VITE_SERVICE_KEY}`,
+        servId: programIdx
+      }
+    }).then((response) => {
+      const res = response.data.data;
+      console.log(res);
+      const obj = {
+        servNm: res.servNm,
+        servDgst: res.servDgst,
+        inqplCtadrList: res.inqplCtadrList,
+        lifeNmArray: res.lifeNmArray,
+        intrsThemaNmArray: res.intrsThemaNmArray,
+        bizChrDeptNm: res.bizChrDeptNm,
+        alwServCn: res.alwServCn,
+        aplyMtdCn: res.aplyMtdCn,
+        sprtTrgtCn: res.sprtTrgtCn,
+        slctCritCn: res.slctCritCn,
+        basfrmList: res.basfrmList
+      }
+      setDetailInfo(obj);
+    })
+    .catch((err) => console.log(err));
   }
+
+  useEffect(() => {
+    getDetail();
+  }, [])
+
+  function reduceLen(len, str) {
+    if(str.length >= len) {
+      str = str.slice(0, len);
+      str += '...';
+      return str;
+    }
+    return str;
+  }
+
+  const btnClick = () => {
+		const absoluteUrl = new URL(`http://${detailInfo.inqplHmpgReldList[0].wlfareInfoReldNm}`, window.location.href).toString();
+    window.open(absoluteUrl, "_blank");
+	}
 
   return(
     <ProgramDetailContainer>
       <DetailHeader>
-        <div id="program-title">{data.title}</div>
+        <div id="program-title">{detailInfo.servNm}</div>
         <DetailInfoBox>
           <div id="program-info__content">
             <DetailInfoLine id="program-info__inquiries-line">
               <div className="program-info__content-title" id="program-info__inquiries">문의처</div>
-              <div>{data.inquiries}</div>
+              <div>{detailInfo.inqplCtadrList[0].wlfareInfoReldCn}</div>
             </DetailInfoLine>
             <DetailInfoLine>
               <div className="program-info__content-title">가구상황</div>
-              <div>{data.household}</div>
+              <div>{reduceLen(10, detailInfo.lifeNmArray)}</div>
             </DetailInfoLine>
             <DetailInfoLine>
               <div className="program-info__content-title">담당부처</div>
-              <div>{data.department} {data.organization}</div>
+              <div>{detailInfo.bizChrDeptNm}</div>
             </DetailInfoLine>
             <DetailInfoLine>
               <div className="program-info__content-title">관심분야</div>
-              <div>{data.interest}</div>
+              <div>{detailInfo.intrsThemaNmArray}</div>
             </DetailInfoLine>
           </div>
         </DetailInfoBox>
       </DetailHeader>
       <DetailContent>
-        {data.detail}
+        {/* {detailInfo.servDgst} */}
+        <DetailContentBlock>
+          <div className="detail-block__title">✔ 제도 정보</div>
+          <div className="detail-block__desc">{detailInfo.servDgst}</div>
+        </DetailContentBlock>
+        <DetailContentBlock>
+          <div className="detail-block__title">✔ 급여 정보</div>
+          <div className="detail-block__desc">{detailInfo.alwServCn}</div>
+        </DetailContentBlock>
+        <DetailContentBlock>
+          <div className="detail-block__title">✔ 신청 방법</div>
+          <div className="detail-block__desc">{detailInfo.aplyMtdCn}</div>
+        </DetailContentBlock>
+        <DetailContentBlock>
+          <div className="detail-block__title">✔ 지원 대상</div>
+          <div className="detail-block__desc">{detailInfo.sprtTrgtCn}</div>
+        </DetailContentBlock>
+        <DetailContentBlock>
+          <div className="detail-block__title">✔ 선정 기준</div>
+          <div className="detail-block__desc">{detailInfo.slctCritCn}</div>
+        </DetailContentBlock>
+        <DetailContentBlock>
+          <div className="detail-block__title" 
+            id="detail-block__title-link"
+            onClick={() => window.open(detailInfo.basfrmList[0].wlfareInfoReldCn, "_blank")}>✔ 상세 파일 다운로드</div>
+        </DetailContentBlock>
       </DetailContent>
     </ProgramDetailContainer>
   )

--- a/client/src/components/ProgramDetail/ProgramDetail.styled.js
+++ b/client/src/components/ProgramDetail/ProgramDetail.styled.js
@@ -29,12 +29,8 @@ export const DetailInfoBox = styled.div`
   position: relative;
   font-size: 25px;
 
-  #program-info__inquiries-line {
-    margin-right: 200px;
-  }
-
   #program-info__content {
-    width: 53.625rem;
+    width: 56rem;
     height: 6.5rem;
     position: absolute;
     top: 50%;
@@ -46,7 +42,7 @@ export const DetailInfoBox = styled.div`
 `
 
 export const DetailInfoLine = styled.div`
-  width: max-content;
+  width: 23.75rem;
   height: 2.125rem;
   display: flex;
   margin-right: 64px;
@@ -57,7 +53,7 @@ export const DetailInfoLine = styled.div`
   }
   
   #program-info__inquiries {
-    margin-right: 45px;
+    margin-right: 46px;
   }
 `;
 
@@ -66,4 +62,28 @@ export const DetailContent = styled.div`
   height: max-content;
   font-size: 25px;
   margin-top: 40px;
+`
+
+export const DetailContentBlock = styled.div`
+  width: 58.3125rem;
+  height: max-content;
+  margin-bottom: 2rem;
+
+  .detail-block__title {
+    width: 16rem;
+    height: 2.3125rem;
+    font-size: 25px;
+    font-weight: 700;
+  }
+
+  .detail-block__desc {
+    width: 55rem;
+    height: max-content;
+    margin: 1rem 0 0 2rem;
+  }
+
+  #detail-block__title-link {
+    color: #5873FF;
+    cursor: pointer;
+  }
 `


### PR DESCRIPTION
### 추가 기능
- 복지 검색 상세페이지 api 연결
- 복지 검색 상세페이지 디자인 일부 수정(와프보다 좀 더 보기 좋게 수정했습니다~)

### 추후 개선
- 해당사항 없음

### 화면 캡쳐
![image](https://github.com/googoo9918/software-project-bokha/assets/50830078/0a603baa-8b6d-4e05-ae8a-445689dd3b9f)
![image](https://github.com/googoo9918/software-project-bokha/assets/50830078/abfc63c5-066f-4f99-9763-645a6fd39c4b)
데이터가 비어 있으면 그냥 빈 상태로 출력되게 했고, 상세 파일 다운로드를 클릭하면, 파일이 클릭한 사람 로컬에 다운로드 됩니다!